### PR TITLE
fix: Revert `rel_data_path` to upstream value

### DIFF
--- a/src/f5_tts/model/dataset.py
+++ b/src/f5_tts/model/dataset.py
@@ -362,7 +362,7 @@ def load_dataset(
     print("Loading dataset ...")
 
     if dataset_type == "CustomDataset":
-        rel_data_path = str(f'/home/yl4579/F5-TTS-diff/F5-TTS-DMD-flow-ds/data/{dataset_name}_{tokenizer}')
+        rel_data_path = str(files("f5_tts").joinpath(f"../../data/{dataset_name}_{tokenizer}"))
         if 'LibriTTS_100_360_500_char_pinyin' in rel_data_path:
             rel_data_path = rel_data_path.replace('LibriTTS_100_360_500_char_pinyin', 'LibriTTS_100_360_500_char')
         if audio_type == "raw":


### PR DESCRIPTION
You missed this change when you did [this commit](https://github.com/yl4579/DMOSpeech2/commit/51fc8743008408774a8393bfd47793a71e48c178). The upstream value for `rel_data_path` in this PR has been sourced from the [equivalent file upstream](https://github.com/SWivid/F5-TTS/blob/e67d50841e08ffa6ac23c26ed14dfe8659124b5e/src/f5_tts/model/dataset.py#L259C9-L259C23).