### PR TITLE
chore: Support supplying the vocoder model locally

### DIFF
--- a/src/infer.py
+++ b/src/infer.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch.nn.utils.rnn import pad_sequence
 from torchdiffeq import odeint
 from safetensors.torch import load_file
-import IPython.display as ipd
+from pathlib import Path
 
 # Import F5-TTS modules
 from f5_tts.model import CFM, UNetT, DiT
@@ -126,7 +126,16 @@ class DMOInference:
         
     def _setup_vocoder(self):
         """Initialize vocoder."""
-        self.vocos = load_vocoder(is_local=False, local_path="")
+        # Provide path via ENV to a local copy of the model (otherwise it will be downloaded from HF):
+        # https://huggingface.co/charactr/vocos-mel-24khz
+        model_dir = Path(os.environ.get("MODEL_DIR_VOCODER", ""))
+        required_files = ["config.yaml", "pytorch_model.bin"]
+
+        if model_dir.is_dir() and all((model_dir / f).is_file() for f in required_files):
+            self.vocos = load_vocoder(is_local=True, local_path=model_dir)
+        else:
+            self.vocos = load_vocoder(is_local=False, local_path="")
+
         self.vocos = self.vocos.to(self.device)
         
     def _setup_duration_predictor(self, checkpoint_path):


### PR DESCRIPTION
This removes a dependency upon HuggingFace network request at runtime. The model can instead be provided upfront locally, as is supported by the F5-TTS equivalent method called. This makes it opt-in via the ENV `MODEL_DIR_VOCODER` being configured and having the Vocos model files F5-TTS requires.

I chose an new ENV as it may not be reliable / consistent to place the model at the HF cache path used:
```
/root/.cache/huggingface/hub/models--charactr--vocos-mel-24khz/snapshots/0feb3fdd929bcd6649e0e7c5a688cf7dd012ef21/pytorch_model.bin
```

I think this also depends upon a network request regardless, so this permits running the model if the network is unstable too.

---

**Example usage:**

```bash
mkdir --parents ckpts models/dmo-speech-2 models/vocos-mel-24khz
ln --symbolic ../models/dmo-speech-2/model_1500.pt ckpts/model_1500.pt
ln --symbolic ../models/dmo-speech-2/model_85000.pt ckpts/model_85000.pt

# 271M (GRPO-finetuned duration predictor checkpoint) + 4GB (DMOSpeech checkpoint):
wget -P models/dmo-speech-2 https://huggingface.co/yl4579/DMOSpeech2/resolve/main/model_1500.pt
wget -P models/dmo-speech-2 https://huggingface.co/yl4579/DMOSpeech2/resolve/main/model_85000.pt

# 55MB (Vocos - Neural Vocoder):
wget -P models/vocos-mel-24khz https://huggingface.co/charactr/vocos-mel-24khz/resolve/main/config.yaml
wget -P models/vocos-mel-24khz https://huggingface.co/charactr/vocos-mel-24khz/resolve/main/pytorch_model.bin

# Run custom entrypoint (eg: similar to `src/demo.ipynb`):
MODEL_DIR_VOCODER=models/vocos-mel-24khz uv run main.py
```

---

**NOTE:** `import IPython.display as ipd` seems unintentional and was removed (as also proposed by https://github.com/yl4579/DMOSpeech2/pull/4).